### PR TITLE
Add usage details for PyLTSpice example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # LTspice_automation
-Playing with the Pyltspice python library
+
+This repository contains a small example using the [PyLTSpice](https://pypi.org/project/PyLTSpice/) library to automate LTspice simulations.
+
+## Prerequisites
+
+- [LTspice](https://www.analog.com/en/design-center/design-tools-and-calculators/ltspice-simulator.html) must be installed and available on your system.
+- Install the Python package `PyLTSpice`:
+
+```bash
+pip install PyLTSpice
+```
+
+## Running the example
+
+The `pyltspicetest1.py` script creates a simple RC circuit netlist, runs LTspice, and prints a few data points from the simulation results. Execute it with Python:
+
+```bash
+python pyltspicetest1.py
+```
+
+Upon completion, the script generates:
+
+- `simple_rc.net` – the generated netlist file
+- `temp_sim_output/` – directory containing the `.raw` and `.log` simulation output files
+
+## Cleaning up
+
+To remove the generated files after running the example, delete the netlist and output directory:
+
+```bash
+rm simple_rc.net
+rm -r temp_sim_output
+```


### PR DESCRIPTION
## Summary
- expand README with prerequisites and how to run the example
- document output files and cleanup instructions

## Testing
- `python3 -m py_compile pyltspicetest1.py`

------
https://chatgpt.com/codex/tasks/task_e_684210a9298c83278b81ddd55da84a43