### PR TITLE
Ensure netlist starts at column zero

### DIFF
--- a/pyltspicetest1.py
+++ b/pyltspicetest1.py
@@ -1,5 +1,6 @@
 from PyLTSpice import SpiceEditor, SimRunner, RawRead
 import sys
+import textwrap
 def main():
     
     # --- 1. Define the Netlist Content ---
@@ -19,7 +20,7 @@ def main():
     print(f"Creating and writing netlist content to file: {netlist_file_name}")
     try:
         with open(netlist_file_name, 'w', encoding='utf-8') as f:
-            f.write(netlist_content)
+            f.write(textwrap.dedent(netlist_content))
         print(f"Netlist file '{netlist_file_name}' created and written successfully.")
     except IOError as e:
         print(f"FATAL ERROR: Could not write netlist file {netlist_file_name}: {e}")


### PR DESCRIPTION
## Summary
- ensure there are no leading spaces in the generated LTspice netlist by using `textwrap.dedent`

## Testing
- `python -m py_compile pyltspicetest1.py`

------
https://chatgpt.com/codex/tasks/task_e_68431d5158648327af557643db1498d5