### PR TITLE
Add matplotlib plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,16 @@ This repository contains a small example using the [PyLTSpice](https://pypi.org/
 ```bash
 pip install PyLTSpice
 ```
+- Install the Python package `matplotlib` for plotting:
+
+```bash
+pip install matplotlib
+```
 
 ## Running the example
 
-The `pyltspicetest1.py` script creates a simple RC circuit netlist, runs LTspice, and prints a few data points from the simulation results. Execute it with Python:
+The `pyltspicetest1.py` script creates a simple RC circuit netlist, runs LTspice,
+and displays a matplotlib plot of the capacitor voltage over time. Execute it with Python:
 
 ```bash
 python pyltspicetest1.py

--- a/pyltspicetest1.py
+++ b/pyltspicetest1.py
@@ -1,6 +1,8 @@
 from PyLTSpice import SpiceEditor, SimRunner, RawRead
 import sys
 import textwrap
+import matplotlib.pyplot as plt
+
 def main():
     
     # --- 1. Define the Netlist Content ---
@@ -83,6 +85,15 @@ def main():
         print("----------------|---------------")
         for i in range(min(10, len(time_trace.get_wave()))):
             print(f"{time_trace.get_wave()[i]:<15.6e} | {v_cap.get_wave()[i]:<15.6e}")
+
+        # Plot voltage vs time using matplotlib
+        plt.figure()
+        plt.plot(time_trace.get_wave(), v_cap.get_wave())
+        plt.title("Capacitor Voltage vs Time")
+        plt.xlabel("Time (s)")
+        plt.ylabel("Voltage (V)")
+        plt.grid(True)
+        plt.show()
     else:
         print(
             f"\nError: Trace '{trace_name_capacitor_voltage}' not found in the raw file."


### PR DESCRIPTION
## Summary
- visualize capacitor voltage over time using matplotlib
- mention matplotlib dependency and plotting functionality in README

## Testing
- `python -m py_compile pyltspicetest1.py`

------
https://chatgpt.com/codex/tasks/task_e_68432b3defd48327ac0fec27ef2bd475