### PR TITLE
Add GUI runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ and displays a matplotlib plot of the capacitor voltage over time. Execute it wi
 python pyltspicetest1.py
 ```
 
+### Using the simple GUI
+
+Alternatively, run the `gui_runtime.py` script to open a small window with a
+**RUN** button. Clicking the button performs the same simulation and displays
+the resulting plot.
+
+```bash
+python gui_runtime.py
+```
+
 Upon completion, the script generates:
 
 - `simple_rc.net` – the generated netlist file

--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -1,0 +1,26 @@
+import tkinter as tk
+from tkinter import messagebox
+
+import pyltspicetest1
+
+
+def run_simulation():
+    """Run the LTspice simulation and show results."""
+    try:
+        pyltspicetest1.main()
+    except Exception as exc:
+        messagebox.showerror("Error", f"Simulation failed: {exc}")
+
+
+def main():
+    root = tk.Tk()
+    root.title("LTspice Runtime")
+
+    run_button = tk.Button(root, text="RUN", command=run_simulation)
+    run_button.pack(padx=20, pady=20)
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `gui_runtime.py` script with a RUN button to start LTspice simulations
- document the GUI option in the README

## Testing
- `python -m py_compile pyltspicetest1.py gui_runtime.py`

------
https://chatgpt.com/codex/tasks/task_e_68432e29338c8327b8f6dd7a40fcd085