### PR TITLE
Add GUI controls for simulation parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ and displays a matplotlib plot of the capacitor voltage over time. Execute it wi
 python pyltspicetest1.py
 ```
 
-### Using the simple GUI
+### Using the GUI
 
-Alternatively, run the `gui_runtime.py` script to open a small window with a
-**RUN** button. Clicking the button performs the same simulation and displays
-the resulting plot.
+Run the `gui_runtime.py` script to open a small window with controls for the
+simulation. Spin boxes allow you to set the source frequency, resistor and
+capacitor values and the stop time of the transient analysis. After selecting
+the desired values, click **RUN** to launch LTspice and plot the result.
 
 ```bash
 python gui_runtime.py

--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -25,10 +25,46 @@ def main():
     canvas_widget = canvas.get_tk_widget()
     canvas_widget.pack(fill=tk.BOTH, expand=True)
 
+    controls = tk.Frame(root)
+    controls.pack(padx=10, pady=10)
+
+    freq_var = tk.DoubleVar(value=1000)
+    tk.Label(controls, text="Frequency (Hz)").grid(row=0, column=0, sticky="e")
+    freq_spin = tk.Spinbox(controls, from_=10, to=100000, increment=10,
+                           textvariable=freq_var, width=10)
+    freq_spin.grid(row=0, column=1, sticky="w")
+
+    res_var = tk.DoubleVar(value=1000)
+    tk.Label(controls, text="Resistor (Ohm)").grid(row=1, column=0, sticky="e")
+    res_spin = tk.Spinbox(controls, from_=100, to=10000, increment=100,
+                          textvariable=res_var, width=10)
+    res_spin.grid(row=1, column=1, sticky="w")
+
+    cap_var = tk.DoubleVar(value=1.0)
+    tk.Label(controls, text="Capacitor (uF)").grid(row=2, column=0, sticky="e")
+    cap_spin = tk.Spinbox(controls, from_=0.1, to=10.0, increment=0.1,
+                          textvariable=cap_var, width=10)
+    cap_spin.grid(row=2, column=1, sticky="w")
+
+    time_var = tk.DoubleVar(value=5.0)
+    tk.Label(controls, text="Stop Time (ms)").grid(row=3, column=0, sticky="e")
+    time_spin = tk.Spinbox(controls, from_=1.0, to=100.0, increment=1.0,
+                           textvariable=time_var, width=10)
+    time_spin.grid(row=3, column=1, sticky="w")
+
     def run_simulation():
-        """Run the LTspice simulation and plot the results."""
+        """Run the LTspice simulation and plot the results using current settings."""
+        freq = freq_var.get()
+        res = res_var.get()
+        cap = cap_var.get() * 1e-6  # convert uF to F
+        stop_t = time_var.get() * 1e-3  # convert ms to s
         try:
-            time_wave, v_cap_wave = pyltspicetest1.run_simulation()
+            time_wave, v_cap_wave = pyltspicetest1.run_simulation(
+                freq_hz=freq,
+                resistor_ohm=res,
+                capacitor_f=cap,
+                stop_time_s=stop_t,
+            )
         except Exception as exc:
             messagebox.showerror("Error", f"Simulation failed: {exc}")
             return

--- a/pyltspicetest1.py
+++ b/pyltspicetest1.py
@@ -4,15 +4,28 @@ import textwrap
 import matplotlib.pyplot as plt
 
 
-def run_simulation():
-    """Run the LTspice simulation and return time and voltage traces."""
+def run_simulation(freq_hz=1e3, resistor_ohm=1e3, capacitor_f=1e-6, stop_time_s=5e-3):
+    """Run the LTspice simulation with the provided values.
+
+    Parameters
+    ----------
+    freq_hz : float, optional
+        Sine source frequency in Hertz.
+    resistor_ohm : float, optional
+        Resistance value in Ohms.
+    capacitor_f : float, optional
+        Capacitance value in Farads.
+    stop_time_s : float, optional
+        Transient analysis stop time in seconds.
+    """
 
     # --- 1. Define the Netlist Content ---
-    netlist_content = """* Simple RC Circuit
-    V1 N001 0 SINE(0 1 1k) ; Voltage source: 1V amplitude, 1kHz
-    R1 N001 N002 1k         ; Resistor: 1k Ohm
-    C1 N002 0 1uF           ; Capacitor: 1uF
-    .tran 0 5m 0 1u         ; Transient analysis: 0 to 5ms, 1us step
+    step_time = stop_time_s / 1000 if stop_time_s > 0 else 1e-6
+    netlist_content = f"""* Simple RC Circuit
+    V1 N001 0 SINE(0 1 {freq_hz}) ; Voltage source: 1V amplitude
+    R1 N001 N002 {resistor_ohm}
+    C1 N002 0 {capacitor_f}
+    .tran 0 {stop_time_s} 0 {step_time}
     .end
     """
 
@@ -33,12 +46,10 @@ def run_simulation():
     # --- 3. Initialize SpiceEditor with the NOW EXISTING file ---
     print(f"Initializing SpiceEditor with existing file: {netlist_file_name}")
     try:
-        # Now that the file exists and has content, SpiceEditor should be able to open and parse it.
         netlist_editor_obj = SpiceEditor(netlist_file_name)
-        print("SpiceEditor initialized successfully.")
-        # There's no need to call .set_text() or .save() here if the file
-        # already contains the complete and correct netlist and we don't
-        # intend to modify it further with SpiceEditor methods at this stage.
+        netlist_editor_obj.set_text(textwrap.dedent(netlist_content))
+        netlist_editor_obj.save()
+        print("SpiceEditor initialized and netlist content updated.")
     except Exception as e:
         print(f"FATAL ERROR: Could not initialize SpiceEditor with file {netlist_file_name}: {e}")
         raise


### PR DESCRIPTION
## Summary
- enable customizing frequency, resistor, capacitor, and stop time
- use `SpiceEditor` to rewrite the netlist with selected values
- expose spin boxes in the GUI to modify simulation parameters
- update README with GUI usage

## Testing
- `python -m py_compile pyltspicetest1.py gui_runtime.py`
- `python pyltspicetest1.py` *(fails: ModuleNotFoundError: No module named 'PyLTSpice')*
- `python gui_runtime.py` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_684333936d908327b6e3c01760610e73