### PR TITLE
Fix SpiceEditor initialization

### DIFF
--- a/pyltspicetest1.py
+++ b/pyltspicetest1.py
@@ -56,9 +56,15 @@ def run_simulation(freq_hz=1e3, resistor_ohm=1e3, capacitor_f=1e-6, stop_time_s=
         if callable(save_fn):
             save_fn()
         else:
+            # ``save_netlist`` has changed signatures across PyLTSpice
+            # versions.  Prefer calling it without arguments first and,
+            # if that fails, retry passing the current netlist file name.
             save_netlist_fn = getattr(netlist_editor_obj, "save_netlist", None)
             if callable(save_netlist_fn):
-                save_netlist_fn()
+                try:
+                    save_netlist_fn()
+                except TypeError:
+                    save_netlist_fn(netlist_file_name)
         print("SpiceEditor initialized.")
     except Exception as e:
         print(f"FATAL ERROR: Could not initialize SpiceEditor with file {netlist_file_name}: {e}")


### PR DESCRIPTION
## Summary
- handle PyLTSpice `save_netlist` signature changes

## Testing
- `python -m py_compile pyltspicetest1.py gui_runtime.py`

------
https://chatgpt.com/codex/tasks/task_e_68433ad507c083279ad41a16af8562b2