### PR TITLE
Update LTspice demo to use op-amp netlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ pip install matplotlib
 
 ## Running the example
 
-The `pyltspicetest1.py` script creates a simple RC circuit netlist, runs LTspice,
-and displays a matplotlib plot of the capacitor voltage over time. Execute it with Python:
+The `pyltspicetest1.py` script creates a small op-amp test netlist using the
+LM7171 model, runs LTspice, and displays a matplotlib plot of the output
+voltage over time. Execute it with Python:
 
 ```bash
 python pyltspicetest1.py
@@ -27,10 +28,8 @@ python pyltspicetest1.py
 
 ### Using the GUI
 
-Run the `gui_runtime.py` script to open a small window with controls for the
-simulation. Spin boxes allow you to set the source frequency, resistor and
-capacitor values and the stop time of the transient analysis. After selecting
-the desired values, click **RUN** to launch LTspice and plot the result.
+Run the `gui_runtime.py` script to open a small window with a **RUN** button.
+Press **RUN** to launch LTspice and plot the simulation result.
 
 ```bash
 python gui_runtime.py
@@ -38,7 +37,7 @@ python gui_runtime.py
 
 Upon completion, the script generates:
 
-- `simple_rc.net` – the generated netlist file
+- `opamp_test.net` – the generated netlist file
 - `temp_sim_output/` – directory containing the `.raw` and `.log` simulation output files
 
 ## Cleaning up
@@ -46,6 +45,6 @@ Upon completion, the script generates:
 To remove the generated files after running the example, delete the netlist and output directory:
 
 ```bash
-rm simple_rc.net
+rm opamp_test.net
 rm -r temp_sim_output
 ```

--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -28,57 +28,26 @@ def main():
     canvas_widget = canvas.get_tk_widget()
     canvas_widget.pack(fill=tk.BOTH, expand=True)
 
-    freq_var = tk.DoubleVar(value=1.0)
-    tk.Label(controls, text="Frequency (kHz)").grid(row=0, column=0, sticky="e")
-    freq_spin = tk.Spinbox(controls, from_=0.01, to=100.0, increment=0.1,
-                           textvariable=freq_var, width=10)
-    freq_spin.grid(row=0, column=1, sticky="w")
 
-    res_var = tk.DoubleVar(value=1000)
-    tk.Label(controls, text="Resistor (Ohm)").grid(row=0, column=2, sticky="e")
-    res_spin = tk.Spinbox(controls, from_=100, to=10000, increment=100,
-                          textvariable=res_var, width=10)
-    res_spin.grid(row=0, column=3, sticky="w")
-
-    cap_var = tk.DoubleVar(value=1.0)
-    tk.Label(controls, text="Capacitor (uF)").grid(row=1, column=0, sticky="e")
-    cap_spin = tk.Spinbox(controls, from_=0.1, to=10.0, increment=0.1,
-                          textvariable=cap_var, width=10)
-    cap_spin.grid(row=1, column=1, sticky="w")
-
-    time_var = tk.DoubleVar(value=5.0)
-    tk.Label(controls, text="Stop Time (ms)").grid(row=1, column=2, sticky="e")
-    time_spin = tk.Spinbox(controls, from_=1.0, to=100.0, increment=1.0,
-                           textvariable=time_var, width=10)
-    time_spin.grid(row=1, column=3, sticky="w")
 
     def run_simulation():
-        """Run the LTspice simulation and plot the results using current settings."""
-        freq = freq_var.get() * 1e3  # convert kHz to Hz
-        res = res_var.get()
-        cap = cap_var.get() * 1e-6  # convert uF to F
-        stop_t = time_var.get() * 1e-3  # convert ms to s
+        """Run the LTspice simulation and plot the results."""
         try:
-            time_wave, v_cap_wave = pyltspicetest1.run_simulation(
-                freq_hz=freq,
-                resistor_ohm=res,
-                capacitor_f=cap,
-                stop_time_s=stop_t,
-            )
+            time_wave, v_cap_wave = pyltspicetest1.run_simulation()
         except Exception as exc:
             messagebox.showerror("Error", f"Simulation failed: {exc}")
             return
 
         ax.clear()
         ax.plot(time_wave, v_cap_wave)
-        ax.set_title("Capacitor Voltage vs Time")
+        ax.set_title("Output Voltage vs Time")
         ax.set_xlabel("Time (s)")
         ax.set_ylabel("Voltage (V)")
         ax.grid(True)
         canvas.draw()
 
     run_button = tk.Button(controls, text="RUN", command=run_simulation)
-    run_button.grid(row=0, column=4, rowspan=2, padx=(10, 0), pady=0, sticky="ns")
+    run_button.grid(row=0, column=0, padx=5, pady=0, sticky="w")
 
     root.mainloop()
 


### PR DESCRIPTION
## Summary
- update example netlist to an LM7171 op-amp test
- simplify GUI to just a run button
- remove parameter controls from code and documentation

## Testing
- `python -m py_compile pyltspicetest1.py gui_runtime.py`
- `flake8 pyltspicetest1.py gui_runtime.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847380a52348327a2fbb7e024ec26a0