### PR TITLE
Fix SpiceEditor init for op-amp test

### DIFF
--- a/pyltspicetest1.py
+++ b/pyltspicetest1.py
@@ -10,8 +10,7 @@ def run_simulation():
     """Run the LTspice simulation using a fixed op-amp test netlist."""
 
     # --- 1. Define the Netlist Content ---
-    netlist_content = """
-* E:\LTSpice_Models\activeBP2 - Copy\opamptest1.asc
+    netlist_content = textwrap.dedent("""* E:\LTSpice_Models\activeBP2 - Copy\opamptest1.asc
 V4 VCC 0 12
 V5 -VCC 0 -12
 R9 Vout N001 1k
@@ -25,7 +24,7 @@ C1 Vout N001 5p
 .tran 5u
 .backanno
 .end
-"""
+""").lstrip()
 
     # Define file names
     netlist_file_name = "opamp_test.net"


### PR DESCRIPTION
## Summary
- ensure opamp test netlist starts with the expected `*` comment

## Testing
- `python pyltspicetest1.py` *(fails: Simulator executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473b5465e88327994015f7a49b1843