### PR TITLE
Fix simulation file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ This repository contains a small example using the [PyLTSpice](https://pypi.org/
 ## Prerequisites
 
 - [LTspice](https://www.analog.com/en/design-center/design-tools-and-calculators/ltspice-simulator.html) must be installed and available on your system.
+  Ensure the LTspice executable is accessible from the command line. If it is
+  installed in a non-standard location you can specify the path explicitly with
+  `SimRunner.create_from("/path/to/LTspice")`.
 - Install the Python package `PyLTSpice`:
 
 ```bash

--- a/pyltspicetest1.py
+++ b/pyltspicetest1.py
@@ -10,7 +10,10 @@ def run_simulation():
     """Run the LTspice simulation using a fixed op-amp test netlist."""
 
     # --- 1. Define the Netlist Content ---
-    netlist_content = textwrap.dedent("""* E:\LTSpice_Models\activeBP2 - Copy\opamptest1.asc
+    # Use a raw string so backslashes in the Windows path are not interpreted as
+    # escape sequences.  This avoids a ``SyntaxWarning: invalid escape sequence``
+    # when the file is executed on Windows.
+    netlist_content = textwrap.dedent(r"""* E:\LTSpice_Models\activeBP2 - Copy\opamptest1.asc
 V4 VCC 0 12
 V5 -VCC 0 -12
 R9 Vout N001 1k
@@ -81,12 +84,15 @@ C1 Vout N001 5p
         print(f"Error: LTSpice simulation failed – {e}")
         raise
 
+    if raw_file_path is None:
+        raise RuntimeError("LTspice did not generate a raw output file")
+
     print(f"Simulation output (raw file): {raw_file_path}")
 
     # --- 5. Read the Simulation Output File ---
     print("\nReading simulation output...")
     try:
-        raw_data = RawRead(raw_file_path)
+        raw_data = RawRead(str(raw_file_path))
     except Exception as e:
         print(f"Error reading raw file {raw_file_path}: {e}")
         raise


### PR DESCRIPTION
## Summary
- avoid invalid escape sequence warning by using a raw string for the netlist
- check that LTspice actually produced a `.raw` file
- read the path with `str()` for `RawRead`
- document how to specify the LTspice path in README

## Testing
- `python -m py_compile pyltspicetest1.py gui_runtime.py`

------
https://chatgpt.com/codex/tasks/task_e_68473d1717048327afed413ae07bf9e6