### PR TITLE
Add component value spin controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ current working directory.
 ### Using the GUI
 
 Run the `gui_runtime.py` script to open a small window with a **RUN** button.
+Four spin boxes allow you to set the values of the gain resistor (`R9`),
+input resistor (`R1`), load resistor (`R3`), and feedback capacitor (`C1`).
 Press **RUN** and you will be prompted to select the `LM7171.lib` model file
-used in the example. After selecting the file, LTspice will run and the
-simulation result will be plotted.
+used in the example. After selecting the file, the netlist is updated with the
+spinner values, LTspice runs and the simulation result is plotted.
 
 ```bash
 python gui_runtime.py

--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -22,6 +22,25 @@ def main():
     controls = tk.Frame(root)
     controls.pack(side=tk.TOP, fill=tk.X, padx=10, pady=10)
 
+    # --- Spinner controls for netlist values ---
+    spinner_frame = tk.Frame(controls)
+    spinner_frame.grid(row=0, column=0, sticky="w")
+
+    r9_var = tk.DoubleVar(value=1000)
+    r1_var = tk.DoubleVar(value=500)
+    r3_var = tk.DoubleVar(value=1000)
+    c1_var = tk.DoubleVar(value=5e-12)
+
+    tk.Label(spinner_frame, text="R9 (Gain Ω)").grid(row=0, column=0, padx=5, pady=2, sticky="w")
+    tk.Spinbox(spinner_frame, from_=1, to=1e6, increment=100, textvariable=r9_var, width=8).grid(row=0, column=1, padx=5, pady=2)
+    tk.Label(spinner_frame, text="C1 (F)").grid(row=0, column=2, padx=5, pady=2, sticky="w")
+    tk.Spinbox(spinner_frame, from_=1e-12, to=1e-6, increment=1e-12, textvariable=c1_var, width=8, format="%.2e").grid(row=0, column=3, padx=5, pady=2)
+
+    tk.Label(spinner_frame, text="R1 (Input Ω)").grid(row=1, column=0, padx=5, pady=2, sticky="w")
+    tk.Spinbox(spinner_frame, from_=1, to=1e6, increment=100, textvariable=r1_var, width=8).grid(row=1, column=1, padx=5, pady=2)
+    tk.Label(spinner_frame, text="R3 (Load Ω)").grid(row=1, column=2, padx=5, pady=2, sticky="w")
+    tk.Spinbox(spinner_frame, from_=1, to=1e6, increment=100, textvariable=r3_var, width=8).grid(row=1, column=3, padx=5, pady=2)
+
     figure = plt.Figure(figsize=(5, 4), dpi=100)
     ax = figure.add_subplot(111)
     canvas = FigureCanvasTkAgg(figure, master=root)
@@ -43,7 +62,13 @@ def main():
             return
 
         try:
-            time_wave, v_cap_wave = pyltspicetest1.run_simulation(lib_path)
+            time_wave, v_cap_wave = pyltspicetest1.run_simulation(
+                lib_path,
+                r9_var.get(),
+                r1_var.get(),
+                r3_var.get(),
+                c1_var.get(),
+            )
         except Exception as exc:
             messagebox.showerror("Error", f"Simulation failed: {exc}")
             return
@@ -57,7 +82,7 @@ def main():
         canvas.draw()
 
     run_button = tk.Button(controls, text="RUN", command=run_simulation)
-    run_button.grid(row=0, column=0, padx=5, pady=0, sticky="w")
+    run_button.grid(row=0, column=1, padx=5, pady=0, sticky="w")
 
     root.mainloop()
 

--- a/pyltspicetest1.py
+++ b/pyltspicetest1.py
@@ -7,7 +7,13 @@ import textwrap
 import matplotlib.pyplot as plt
 
 
-def run_simulation(lib_path: str | None = None):
+def run_simulation(
+    lib_path: str | None = None,
+    r9_value: str | float = "1k",
+    r1_value: str | float = "500",
+    r3_value: str | float = "1k",
+    c1_value: str | float = "5p",
+):
     """Run the LTspice simulation using a fixed op-amp test netlist.
 
     Parameters
@@ -16,6 +22,14 @@ def run_simulation(lib_path: str | None = None):
         Optional path to the ``LM7171.lib`` model file. When provided, the
         ``.include`` statement in the generated netlist will reference this
         absolute path. Otherwise the short file name ``lm7171.lib`` is used.
+    r9_value:
+        Value of the gain resistor ``R9``.
+    r1_value:
+        Value of the input resistor ``R1``.
+    r3_value:
+        Value of the load resistor ``R3``.
+    c1_value:
+        Value of the feedback capacitor ``C1``.
     """
 
     # --- 1. Define the Netlist Content ---
@@ -32,12 +46,12 @@ def run_simulation(lib_path: str | None = None):
         "* E:\\LTSpice_Models\\activeBP2 - Copy\\opamptest1.asc",
         "V4 VCC 0 12",
         "V5 -VCC 0 -12",
-        "R9 Vout N001 1k",
+        f"R9 Vout N001 {r9_value}",
         "XU2 N003 N001 VCC -VCC Vout LM7171",
-        "R3 Vout 0 1K",
+        f"R3 Vout 0 {r3_value}",
         "V1 N002 0 PULSE(0 1 0 1n 1n 1u 2u)",
-        "R1 N003 N002 500",
-        "C1 Vout N001 5p",
+        f"R1 N003 N002 {r1_value}",
+        f"C1 Vout N001 {c1_value}",
         include_line,
         "* .ac dec 100 1K 20000K",
         ".tran 5u",


### PR DESCRIPTION
## Summary
- allow editing resistor/capacitor values through new spin boxes
- pass these values to the LTspice simulation
- document the new GUI controls

## Testing
- `pytest -q`
- `python -m py_compile gui_runtime.py pyltspicetest1.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_6849c7962b208327ba67b3b6595d6247