### PR TITLE
Add persistent op-amp model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,16 @@ current working directory.
 
 ### Using the GUI
 
-Run the `gui_runtime.py` script to open a small window with a **RUN** button.
-Four spin boxes allow you to set the values of the gain resistor (`R9`),
-input resistor (`R1`), load resistor (`R3`), and feedback capacitor (`C1`).
-Press **RUN** and you will be prompted to select the `LM7171.lib` model file
-used in the example. After selecting the file, the netlist is updated with the
-spinner values, LTspice runs and the simulation result is plotted.
+Run the `gui_runtime.py` script to open a small window with a **RUN** button
+and a **Load Model** button. Four spin boxes allow you to set the values of the
+gain resistor (`R9`), input resistor (`R1`), load resistor (`R3`), and feedback
+capacitor (`C1`).
+
+Click **Load Model** to select the op-amp model file. The selected file is
+remembered across runs and its name is displayed to the right of the **RUN**
+button. Press **RUN** to run the simulation using the currently loaded model.
+The netlist is updated with the spinner values and the simulation result is
+plotted.
 
 ```bash
 python gui_runtime.py


### PR DESCRIPTION
## Summary
- remember last used op-amp model
- display loaded model name next to **RUN** button
- add **Load Model** button
- document new workflow

## Testing
- `python -m py_compile gui_runtime.py pyltspicetest1.py`
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6849d0b6c5c88327b3b3ee6f085bd27e