### PR TITLE
Adjust C1 increment step

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If the model path is omitted, `LM7171.lib` is used.
 Run the `gui_runtime.py` script to open a small window with a **RUN** button
 and a **Load Model** button. Four spin boxes allow you to set the values of the
 gain resistor (`R9`), input resistor (`R1`), load resistor (`R3`), and feedback
-capacitor (`C1`).
+capacitor (`C1`). The C1 spin box increments in 1&nbsp;pF steps.
 
 Click **Load Model** to select the op-amp model file. The selected file is
 remembered across runs and its name is displayed to the right of the **RUN**

--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -7,6 +7,9 @@ import matplotlib.pyplot as plt
 
 import pyltspicetest1
 
+# Spinner constants
+ONE_PF = 1e-12
+
 
 def main():
     root = tk.Tk()
@@ -42,9 +45,9 @@ def main():
     # works on all systems.
     tk.Spinbox(
         spinner_frame,
-        from_=1e-12,
+        from_=ONE_PF,
         to=1e-6,
-        increment=1e-12,
+        increment=ONE_PF,
         textvariable=c1_var,
         width=8,
     ).grid(row=0, column=3, padx=5, pady=2)


### PR DESCRIPTION
## Summary
- add a constant for the C1 spin box step
- use the constant so the C1 spinner changes in 1 pF increments
- document the C1 step in the README

## Testing
- `python3 -m py_compile gui_runtime.py pyltspicetest1.py`
- `pip install matplotlib`
- `pip install PyLTSpice`
- `python3 gui_runtime.py` *(fails: no $DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_6849e5768ae48327baa8f7549d79cac3