### PR TITLE
Add C2 and C3 controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,12 @@ If the model path is omitted, `LM7171.lib` is used.
 ### Using the GUI
 
 Run the `gui_runtime.py` script to open a small window with a **RUN** button
-and a **Load Model** button. Four spin boxes allow you to set the values of the
-gain resistor (`R9`), input resistor (`R1`), load resistor (`R3`), and feedback
-capacitor (`C1`). The C1 spin box increments in 1&nbsp;pF steps.
+and a **Load Model** button. Six spin boxes allow you to set the values of the
+gain resistor (`R9`), input resistor (`R1`), load resistor (`R3`), feedback
+capacitor (`C1`), input capacitor (`C2`), and load capacitor (`C3`). The
+capacitor spin boxes increment in 1&nbsp;pF steps.
+The `C2` and `C3` controls appear to the right of the `C1` and `R3` pair, stacked
+vertically, with the **RUN** and **Load Model** buttons on their right.
 
 Click **Load Model** to select the op-amp model file. The selected file is
 remembered across runs and its name is displayed to the right of the **RUN**

--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -34,6 +34,8 @@ def main():
     r1_var = tk.DoubleVar(value=500)
     r3_var = tk.DoubleVar(value=1000)
     c1_var = tk.DoubleVar(value=5e-12)
+    c2_var = tk.DoubleVar(value=2e-12)
+    c3_var = tk.DoubleVar(value=2e-12)
 
     tk.Label(spinner_frame, text="R9 (Gain Ω)").grid(row=0, column=0, padx=5, pady=2, sticky="w")
     tk.Spinbox(spinner_frame, from_=1, to=1e6, increment=100, textvariable=r9_var, width=8).grid(row=0, column=1, padx=5, pady=2)
@@ -68,10 +70,54 @@ def main():
         )
     c1_spinbox.grid(row=0, column=3, padx=5, pady=2)
 
+    tk.Label(spinner_frame, text="C2 (F)").grid(row=0, column=4, padx=5, pady=2, sticky="w")
+    try:
+        c2_spinbox = tk.Spinbox(
+            spinner_frame,
+            from_=ONE_PF,
+            to=1e-6,
+            increment=ONE_PF,
+            format="%g",
+            textvariable=c2_var,
+            width=8,
+        )
+    except tk.TclError:
+        c2_spinbox = tk.Spinbox(
+            spinner_frame,
+            from_=ONE_PF,
+            to=1e-6,
+            increment=ONE_PF,
+            textvariable=c2_var,
+            width=8,
+        )
+    c2_spinbox.grid(row=0, column=5, padx=5, pady=2)
+
     tk.Label(spinner_frame, text="R1 (Input Ω)").grid(row=1, column=0, padx=5, pady=2, sticky="w")
     tk.Spinbox(spinner_frame, from_=1, to=1e6, increment=100, textvariable=r1_var, width=8).grid(row=1, column=1, padx=5, pady=2)
     tk.Label(spinner_frame, text="R3 (Load Ω)").grid(row=1, column=2, padx=5, pady=2, sticky="w")
     tk.Spinbox(spinner_frame, from_=1, to=1e6, increment=100, textvariable=r3_var, width=8).grid(row=1, column=3, padx=5, pady=2)
+
+    tk.Label(spinner_frame, text="C3 (F)").grid(row=1, column=4, padx=5, pady=2, sticky="w")
+    try:
+        c3_spinbox = tk.Spinbox(
+            spinner_frame,
+            from_=ONE_PF,
+            to=1e-6,
+            increment=ONE_PF,
+            format="%g",
+            textvariable=c3_var,
+            width=8,
+        )
+    except tk.TclError:
+        c3_spinbox = tk.Spinbox(
+            spinner_frame,
+            from_=ONE_PF,
+            to=1e-6,
+            increment=ONE_PF,
+            textvariable=c3_var,
+            width=8,
+        )
+    c3_spinbox.grid(row=1, column=5, padx=5, pady=2)
 
     figure = plt.Figure(figsize=(5, 4), dpi=100)
     ax = figure.add_subplot(111)
@@ -136,6 +182,8 @@ def main():
                 r1_var.get(),
                 r3_var.get(),
                 c1_var.get(),
+                c2_var.get(),
+                c3_var.get(),
             )
         except Exception as exc:
             messagebox.showerror("Error", f"Simulation failed: {exc}")

--- a/pyltspicetest1.py
+++ b/pyltspicetest1.py
@@ -31,6 +31,8 @@ def run_simulation(
     r1_value: str | float = "1k",
     r3_value: str | float = "1k",
     c1_value: str | float = "5p",
+    c2_value: str | float = "2p",
+    c3_value: str | float = "2p",
 ):
     """Run the LTspice simulation using a fixed op-amp test netlist.
 
@@ -49,6 +51,10 @@ def run_simulation(
         Value of the load resistor ``R3``.
     c1_value:
         Value of the feedback capacitor ``C1``.
+    c2_value:
+        Value of the input capacitor ``C2``.
+    c3_value:
+        Value of the load capacitor ``C3``.
 
     Returns
     -------
@@ -82,6 +88,8 @@ def run_simulation(
         "V1 N002 0 PULSE(0 1 0 1n 1n 1u 2u)",
         f"R1 N001 0 {r1_value}",
         f"C1 Vout N001 {c1_value}",
+        f"C2 N002 0 {c2_value}",
+        f"C3 Vout 0 {c3_value}",
         include_line,
         "* .ac dec 100 1K 20000K",
         ".tran 5u",


### PR DESCRIPTION
## Summary
- add input and load capacitors to simulation netlist
- expose C2 and C3 values in GUI spinboxes
- document new spinners in README

## Testing
- `python -m py_compile *.py`
- `python pyltspicetest1.py` *(fails: No module named 'PyLTSpice')*
- `python gui_runtime.py` *(fails: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_684b1ba83f388327a3cb402fdc4311b6