### PR TITLE
Add controls for V1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,13 @@ If the model path is omitted, `LM7171.lib` is used.
 ### Using the GUI
 
 Run the `gui_runtime.py` script to open a small window with a **RUN** button
-and a **Load Model** button. Six spin boxes allow you to set the values of the
+and a **Load Model** button. Eight spin boxes allow you to set the values of the
 gain resistor (`R9`), input resistor (`R1`), load resistor (`R3`), feedback
-capacitor (`C1`), input capacitor (`C2`), and load capacitor (`C3`). The
-capacitor spin boxes increment in 1&nbsp;pF steps.
-The `C2` and `C3` controls appear to the right of the `C1` and `R3` pair, stacked
-vertically, with the **RUN** and **Load Model** buttons on their right.
+capacitor (`C1`), input capacitor (`C2`), load capacitor (`C3`), and the
+amplitude and frequency of the input source `V1`. The capacitor spin boxes
+increment in 1&nbsp;pF steps. The `C2` and `C3` controls appear to the right of
+the `C1` and `R3` pair, stacked vertically. The new `V1` controls are positioned
+to their right, leaving the **RUN** and **Load Model** buttons on the far right.
 
 Click **Load Model** to select the op-amp model file. The selected file is
 remembered across runs and its name is displayed to the right of the **RUN**

--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -36,6 +36,8 @@ def main():
     c1_var = tk.DoubleVar(value=5e-12)
     c2_var = tk.DoubleVar(value=2e-12)
     c3_var = tk.DoubleVar(value=2e-12)
+    v1_amp_var = tk.DoubleVar(value=1.0)
+    v1_freq_var = tk.DoubleVar(value=5e5)
 
     tk.Label(spinner_frame, text="R9 (FB)").grid(row=0, column=0, padx=5, pady=2, sticky="w")
     tk.Spinbox(spinner_frame, from_=1, to=1e6, increment=100, textvariable=r9_var, width=8).grid(row=0, column=1, padx=5, pady=2)
@@ -119,6 +121,26 @@ def main():
         )
     c3_spinbox.grid(row=1, column=5, padx=5, pady=2)
 
+    tk.Label(spinner_frame, text="V1 Amp").grid(row=0, column=6, padx=5, pady=2, sticky="w")
+    tk.Spinbox(
+        spinner_frame,
+        from_=0.0,
+        to=10.0,
+        increment=0.1,
+        textvariable=v1_amp_var,
+        width=8,
+    ).grid(row=0, column=7, padx=5, pady=2)
+
+    tk.Label(spinner_frame, text="V1 Freq (Hz)").grid(row=1, column=6, padx=5, pady=2, sticky="w")
+    tk.Spinbox(
+        spinner_frame,
+        from_=1.0,
+        to=1e7,
+        increment=1000.0,
+        textvariable=v1_freq_var,
+        width=8,
+    ).grid(row=1, column=7, padx=5, pady=2)
+
     figure = plt.Figure(figsize=(5, 4), dpi=100)
     ax = figure.add_subplot(111)
     canvas = FigureCanvasTkAgg(figure, master=root)
@@ -184,6 +206,8 @@ def main():
                 c1_var.get(),
                 c2_var.get(),
                 c3_var.get(),
+                v1_amp_var.get(),
+                v1_freq_var.get(),
             )
         except Exception as exc:
             messagebox.showerror("Error", f"Simulation failed: {exc}")

--- a/pyltspicetest1.py
+++ b/pyltspicetest1.py
@@ -33,6 +33,8 @@ def run_simulation(
     c1_value: str | float = "5p",
     c2_value: str | float = "2p",
     c3_value: str | float = "2p",
+    v1_amplitude: str | float = 1.0,
+    v1_frequency: str | float = 5e5,
 ):
     """Run the LTspice simulation using a fixed op-amp test netlist.
 
@@ -55,6 +57,10 @@ def run_simulation(
         Value of the input capacitor ``C2``.
     c3_value:
         Value of the load capacitor ``C3``.
+    v1_amplitude:
+        Peak value of the input pulse source ``V1`` in volts.
+    v1_frequency:
+        Frequency of the input pulse source ``V1`` in hertz.
 
     Returns
     -------
@@ -78,6 +84,9 @@ def run_simulation(
     except Exception:
         subckt_name = "LM7171"
 
+    period = 1 / float(v1_frequency)
+    ton = period / 2
+
     netlist_lines = [
         "* E:\\LTSpice_Models\\activeBP2 - Copy\\opamptest1.asc",
         "V4 VCC 0 12",
@@ -85,7 +94,7 @@ def run_simulation(
         f"R9 Vout N001 {r9_value}",
         f"XU2 N002 N001 VCC -VCC Vout {subckt_name}",
         f"R3 Vout 0 {r3_value}",
-        "V1 N002 0 PULSE(0 1 0 1n 1n 1u 2u)",
+        f"V1 N002 0 PULSE(0 {v1_amplitude} 0 1n 1n {ton} {period})",
         f"R1 N001 0 {r1_value}",
         f"C1 Vout N001 {c1_value}",
         f"C2 N002 0 {c2_value}",


### PR DESCRIPTION
## Summary
- allow controlling the V1 source amplitude and frequency
- expose the new parameters in the GUI with spin boxes
- document the additional GUI controls

## Testing
- `python -m py_compile gui_runtime.py pyltspicetest1.py`

------
https://chatgpt.com/codex/tasks/task_e_684c653f4324832782df3fcd47efc6ac