### PR TITLE
Add schemdraw-based schematic output

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ pip install PyLTSpice
 ```bash
 pip install matplotlib
 ```
+- The optional package `schemdraw` is required to generate a simple circuit
+  diagram from the netlist:
+
+```bash
+pip install schemdraw
+```
 
 ## Running the example
 
@@ -47,7 +53,8 @@ Click **Load Model** to select the op-amp model file. The selected file is
 remembered across runs and its name is displayed to the right of the **RUN**
 button. Press **RUN** to run the simulation using the currently loaded model.
 The netlist is updated with the spinner values and the simulation result is
-plotted.
+plotted. After each run a simple schematic derived from the netlist is shown to
+the right of the plot.
 
 ```bash
 python gui_runtime.py
@@ -57,6 +64,7 @@ Upon completion, the script generates:
 
 - `opamp_test.net` – the generated netlist file
 - `temp_sim_output/` – directory containing the `.raw` and `.log` simulation output files
+- `opamp_test.svg` – simple schematic created from the netlist
 
 ## Cleaning up
 

--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -141,11 +141,17 @@ def main():
         width=8,
     ).grid(row=1, column=7, padx=5, pady=2)
 
+    display_frame = tk.Frame(root)
+    display_frame.pack(fill=tk.BOTH, expand=True)
+
     figure = plt.Figure(figsize=(5, 4), dpi=100)
     ax = figure.add_subplot(111)
-    canvas = FigureCanvasTkAgg(figure, master=root)
+    canvas = FigureCanvasTkAgg(figure, master=display_frame)
     canvas_widget = canvas.get_tk_widget()
-    canvas_widget.pack(fill=tk.BOTH, expand=True)
+    canvas_widget.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+    schematic_label = tk.Label(display_frame)
+    schematic_label.pack(side=tk.LEFT, fill=tk.BOTH, padx=10)
 
     last_model_file = "last_model.txt"
 
@@ -220,6 +226,15 @@ def main():
         ax.set_ylabel("Voltage (V)")
         ax.grid(True)
         canvas.draw()
+
+        try:
+            svg_path = pyltspicetest1.create_schematic_svg("opamp_test.net")
+            png_path = svg_path.with_suffix(".png")
+            img = tk.PhotoImage(file=str(png_path))
+            schematic_label.configure(image=img)
+            schematic_label.image = img
+        except Exception:
+            schematic_label.configure(text="Schematic unavailable")
 
         slew_label_var.set(f"90-10 Slew Rate: {sr_90_10/1e6:.3f} V/us")
         slew80_label_var.set(f"80-20 Slew Rate: {sr_80_20/1e6:.3f} V/us")


### PR DESCRIPTION
## Summary
- install optional schemdraw dependency
- parse netlist to produce a simple schematic image
- display the schematic in the GUI next to the plot
- document the new feature and dependency

## Testing
- `python -m py_compile pyltspicetest1.py gui_runtime.py`

------
https://chatgpt.com/codex/tasks/task_e_684c835ba5f083279599c43fd02c3eed