### PR TITLE
Fix C1 drawing placement

### DIFF
--- a/pyltspicetest1.py
+++ b/pyltspicetest1.py
@@ -76,16 +76,19 @@ def create_schematic_svg(netlist_path: str | Path) -> Path:
     d += elm.Line().down()
     d += elm.Ground()
 
-    # Feedback resistor R9 above the op-amp
+    # Feedback network above the op-amp: R9 with C1 in parallel
     d += elm.Line().at(n001_top).right()
+    r9_start = d.here
     d += elm.Resistor().right().label("R9")
     r9_end = d.here
     d += elm.Line().at(r9_end).to(op.out)
 
-    # Feedback capacitor C1 from op-amp output
-    d += elm.Line().at(op.out).up()
+    # Capacitor C1 connected across R9 directly above it
+    d.push()
+    d += elm.Line().at(r9_start).up()
     d += elm.Capacitor().right().label("C1")
     d += elm.Line().down().to(r9_end)
+    d.pop()
 
     # Output load (R3 and C3)
     d += elm.Line().at(op.out).right()


### PR DESCRIPTION
## Summary
- update schematic to draw C1 directly above R9
- connect C1 between the two nodes of R9 so the feedback components are parallel

## Testing
- `python -m py_compile pyltspicetest1.py gui_runtime.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c8f9b14f08327982bd94375ae51d8