### PR TITLE
Fix C2 placement in schematic

### DIFF
--- a/pyltspicetest1.py
+++ b/pyltspicetest1.py
@@ -54,14 +54,17 @@ def create_schematic_svg(netlist_path: str | Path) -> Path:
     # Input source and reference ground
     d += elm.Ground()
     d += elm.SourceV().up().label("V1")
-    n002 = d.here
+    source_top = d.here
     d += elm.Line().right()
     op = d.add(elm.Opamp().right())
 
     # Non-inverting input path (N002)
-    d += elm.Line().at(n002).to(op.in1)
+    d += elm.Line().at(source_top).right()
+    n002 = d.here
+    d += elm.Line().at(source_top).to(n002)
     d += elm.Capacitor().at(n002).down().label("C2")
     d += elm.Ground()
+    d += elm.Line().at(n002).to(op.in1)
 
     # Inverting input network (N001)
     d += elm.Line().at(op.in2).left()


### PR DESCRIPTION
## Summary
- update schematic generator so C2 is drawn beside V1

## Testing
- `python -m py_compile pyltspicetest1.py`
- `python -m py_compile gui_runtime.py`

------
https://chatgpt.com/codex/tasks/task_e_684c9121a30483278cc5d7e1ddbdc836