### PR TITLE
Fix V1 wiring in schematic

### DIFF
--- a/pyltspicetest1.py
+++ b/pyltspicetest1.py
@@ -55,16 +55,16 @@ def create_schematic_svg(netlist_path: str | Path) -> Path:
     d += elm.Ground()
     d += elm.SourceV().up().label("V1")
     source_top = d.here
+
+    # Bypass capacitor close to the source
+    d += elm.Capacitor().at(source_top).down().label("C2")
+    d += elm.Ground()
+
     d += elm.Line().right()
     op = d.add(elm.Opamp().right())
 
-    # Non-inverting input path (N002)
-    d += elm.Line().at(source_top).right()
-    n002 = d.here
-    d += elm.Line().at(source_top).to(n002)
-    d += elm.Capacitor().at(n002).down().label("C2")
-    d += elm.Ground()
-    d += elm.Line().at(n002).to(op.in1)
+    # Connect V1 directly to the non-inverting input
+    d += elm.Line().at(source_top).to(op.in1)
 
     # Inverting input network (N001)
     d += elm.Line().at(op.in2).left()


### PR DESCRIPTION
## Summary
- move bypass capacitor C2 next to V1
- connect V1 directly to the op-amp's non-inverting input
- remove unused intermediate node

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c92c11834832797cb042c60b8cdae