### PR TITLE
Remove schemdraw dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,10 @@ pip install PyLTSpice
 ```bash
 pip install matplotlib
 ```
-- The optional package `schemdraw` is required to generate a simple circuit
-  diagram from the netlist:
+- Install the Python package `pillow` for the placeholder image:
 
 ```bash
-pip install schemdraw
+pip install pillow
 ```
 
 ## Running the example
@@ -53,9 +52,8 @@ Click **Load Model** to select the op-amp model file. The selected file is
 remembered across runs and its name is displayed to the right of the **RUN**
 button. Press **RUN** to run the simulation using the currently loaded model.
 The netlist is updated with the spinner values and the simulation result is
-plotted. After each run a simple schematic derived from the netlist is shown to
-the right of the plot. The schematic now connects the components with wires so
-the basic node relationships are visible.
+plotted. After each run a placeholder image showing a red circle is displayed to
+the right of the plot.
 
 ```bash
 python gui_runtime.py
@@ -65,8 +63,7 @@ Upon completion, the script generates:
 
 - `opamp_test.net` – the generated netlist file
 - `temp_sim_output/` – directory containing the `.raw` and `.log` simulation output files
-- `opamp_test.svg` – schematic with connected components created from the
-  netlist
+- `placeholder.png` – simple image containing a red circle
 
 ## Cleaning up
 

--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -228,13 +228,12 @@ def main():
         canvas.draw()
 
         try:
-            svg_path = pyltspicetest1.create_schematic_svg("opamp_test.net")
-            png_path = svg_path.with_suffix(".png")
-            img = tk.PhotoImage(file=str(png_path))
+            img_path = pyltspicetest1.create_placeholder_image("placeholder.png")
+            img = tk.PhotoImage(file=str(img_path))
             schematic_label.configure(image=img)
             schematic_label.image = img
         except Exception:
-            schematic_label.configure(text="Schematic unavailable")
+            schematic_label.configure(text="Image unavailable")
 
         slew_label_var.set(f"90-10 Slew Rate: {sr_90_10/1e6:.3f} V/us")
         slew80_label_var.set(f"80-20 Slew Rate: {sr_80_20/1e6:.3f} V/us")

--- a/pyltspicetest1.py
+++ b/pyltspicetest1.py
@@ -7,9 +7,8 @@ import textwrap
 import matplotlib.pyplot as plt
 import numpy as np
 
-# Optional dependency used to create a simple schematic
-import schemdraw
-from schemdraw import elements as elm
+# Pillow is used to create a placeholder image
+from PIL import Image, ImageDraw
 
 
 def _first_subckt_name(lib_path: Path) -> str:
@@ -29,83 +28,21 @@ def _first_subckt_name(lib_path: Path) -> str:
     raise ValueError(f"Could not determine subcircuit name from {lib_path}")
 
 
-def create_schematic_svg(netlist_path: str | Path) -> Path:
-    """Render a small schematic reflecting the LTspice netlist topology."""
+def create_placeholder_image(image_path: str | Path) -> Path:
+    """Create a PNG with a large red circle and return its path."""
 
-    netlist_path = Path(netlist_path)
-    svg_path = netlist_path.with_suffix(".svg")
+    image_path = Path(image_path).with_suffix(".png")
 
-    # ─── start drawing ──────────────────────────
-    d = schemdraw.Drawing(show=False)
+    size = 200
+    img = Image.new("RGB", (size, size), "white")
+    draw = ImageDraw.Draw(img)
+    radius = size // 2 - 10
+    center = (size // 2, size // 2)
+    bbox = [center[0] - radius, center[1] - radius, center[0] + radius, center[1] + radius]
+    draw.ellipse(bbox, fill="red")
+    img.save(image_path)
 
-    # ── Signal source and reference node (non‑inverting input path) ──
-    gnd = d.add(elm.Ground())
-    src = d.add(elm.SourceV().up().label("V1"))
-    vp = d.here
-
-    # Capacitor C2 from that node to ground
-    d.push()
-    d.add(elm.Capacitor().right().down().label("C2"))
-    d.add(elm.Ground())
-    d.pop()
-
-    # Route the node horizontally towards the op‑amp location
-    d.add(elm.Line().right(1.5))
-    node_plus = d.here
-
-    # ── LM7171 op‑amp – plus input = in2 (lower), minus input = in1 (upper) ──
-    op = d.add(elm.Opamp().at(node_plus).right())
-
-    # Connect non‑inverting (+) input
-    d.add(elm.Line().at(vp).to(op.in2))
-
-    # ── Inverting (–) input network ────────────────────
-    d.add(elm.Line().at(op.in1).left())
-    n_inv = d.here
-
-    # R1 to ground
-    d.push()
-    d.add(elm.Resistor().down().label("R1"))
-    d.add(elm.Ground())
-    d.pop()
-
-    # Lift that node so R9 and C1 can sit above the op‑amp
-    d.add(elm.Line().up(1.5))
-    fb_left = d.here
-
-    # R9 in series, heading right towards Vout
-    r9 = d.add(elm.Resistor().right().label("R9"))
-    fb_right = d.here
-
-    # Down to the op‑amp output
-    d.add(elm.Line().down().to(op.out))
-
-    # C1 in parallel with R9
-    d.push()
-    d.add(elm.Line().at(fb_left).up())
-    d.add(elm.Capacitor().right().label("C1"))
-    d.add(elm.Line().down().to(fb_right))
-    d.pop()
-
-    # ── Output load (R3) and snubber cap (C3) ─────────────
-    d.add(elm.Line().at(op.out).right(1))
-    vout = d.here
-
-    d.add(elm.Resistor().down().label("R3"))
-    d.add(elm.Ground())
-
-    # Small stub to the right before dropping C3
-    d.push()
-    d.add(elm.Line().at(vout).right(1))
-    d.add(elm.Capacitor().down().label("C3"))
-    d.add(elm.Ground())
-    d.pop()
-
-    # ── Finish up ──────────────────────────────
-    d.draw()
-    d.save(str(svg_path))
-    d.save(str(svg_path.with_suffix(".png")))
-    return svg_path
+    return image_path
 
 
 def run_simulation(


### PR DESCRIPTION
## Summary
- replace schematic generation with placeholder red circle image
- draw placeholder image in the GUI
- remove schemdraw from README and add pillow dependency

## Testing
- `python -m py_compile gui_runtime.py pyltspicetest1.py`

------
https://chatgpt.com/codex/tasks/task_e_685067872c3c83278646b6f4957f1274