### PR TITLE
Remove schemdraw schematic generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,10 @@ pip install PyLTSpice
 ```bash
 pip install matplotlib
 ```
-- The optional package `schemdraw` is required to generate a simple circuit
-  diagram from the netlist:
+- Install the Python package `pillow` for drawing a placeholder image:
 
 ```bash
-pip install schemdraw
+pip install pillow
 ```
 
 ## Running the example
@@ -53,9 +52,8 @@ Click **Load Model** to select the op-amp model file. The selected file is
 remembered across runs and its name is displayed to the right of the **RUN**
 button. Press **RUN** to run the simulation using the currently loaded model.
 The netlist is updated with the spinner values and the simulation result is
-plotted. After each run a simple schematic derived from the netlist is shown to
-the right of the plot. The schematic now connects the components with wires so
-the basic node relationships are visible.
+plotted. After each run an image is shown to the right of the plot. For now this
+is simply a large red circle acting as a placeholder for a future schematic.
 
 ```bash
 python gui_runtime.py
@@ -65,8 +63,6 @@ Upon completion, the script generates:
 
 - `opamp_test.net` – the generated netlist file
 - `temp_sim_output/` – directory containing the `.raw` and `.log` simulation output files
-- `opamp_test.svg` – schematic with connected components created from the
-  netlist
 
 ## Cleaning up
 

--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 import matplotlib.pyplot as plt
+from PIL import Image, ImageDraw, ImageTk
 
 import pyltspicetest1
 
@@ -227,14 +228,13 @@ def main():
         ax.grid(True)
         canvas.draw()
 
-        try:
-            svg_path = pyltspicetest1.create_schematic_svg("opamp_test.net")
-            png_path = svg_path.with_suffix(".png")
-            img = tk.PhotoImage(file=str(png_path))
-            schematic_label.configure(image=img)
-            schematic_label.image = img
-        except Exception:
-            schematic_label.configure(text="Schematic unavailable")
+        img_size = 200
+        img = Image.new("RGB", (img_size, img_size), "white")
+        draw = ImageDraw.Draw(img)
+        draw.ellipse((10, 10, img_size - 10, img_size - 10), fill="red")
+        tk_img = ImageTk.PhotoImage(img)
+        schematic_label.configure(image=tk_img)
+        schematic_label.image = tk_img
 
         slew_label_var.set(f"90-10 Slew Rate: {sr_90_10/1e6:.3f} V/us")
         slew80_label_var.set(f"80-20 Slew Rate: {sr_80_20/1e6:.3f} V/us")


### PR DESCRIPTION
## Summary
- drop the schemdraw dependency
- update README instructions accordingly
- show a red circle placeholder image in the GUI after running the simulation

## Testing
- `python -m py_compile gui_runtime.py pyltspicetest1.py`

------
https://chatgpt.com/codex/tasks/task_e_685067872c3c83278646b6f4957f1274