### PR TITLE
Add tran parameter field

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ If the model path is omitted, `LM7171.lib` is used.
 ### Using the GUI
 
 Run the `gui_runtime.py` script to open a small window with a **RUN** button
-and a **Load Model** button. Eight spin boxes allow you to set the values of the
+and a **Load Model** button. Eight spin boxes and one text entry allow you to set the values of the
 gain resistor (`R9`), input resistor (`R1`), load resistor (`R3`), feedback
 capacitor (`C1`), input capacitor (`C2`), load capacitor (`C3`), and the
-amplitude and frequency of the input source `V1`. The capacitor spin boxes
+amplitude and frequency of the input source `V1`. A text field labelled
+`tran` lets you change the parameters of the SPICE `.tran` line. The capacitor spin boxes
 increment in 1&nbsp;pF steps. The `C2` and `C3` controls appear to the right of
 the `C1` and `R3` pair, stacked vertically. The new `V1` controls are positioned
 to their right, leaving the **RUN** and **Load Model** buttons on the far right.

--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -42,6 +42,7 @@ def main():
     c3_var = tk.DoubleVar(value=2e-12)
     v1_amp_var = tk.DoubleVar(value=1.0)
     v1_freq_var = tk.DoubleVar(value=5e5)
+    tran_var = tk.StringVar(value="5u")
 
     tk.Label(spinner_frame, text="R9 (FB)").grid(row=0, column=0, padx=5, pady=2, sticky="w")
     tk.Spinbox(spinner_frame, from_=1, to=1e6, increment=100, textvariable=r9_var, width=8).grid(row=0, column=1, padx=5, pady=2)
@@ -144,6 +145,9 @@ def main():
         textvariable=v1_freq_var,
         width=8,
     ).grid(row=1, column=7, padx=5, pady=2)
+
+    tk.Label(spinner_frame, text="tran").grid(row=2, column=0, padx=5, pady=2, sticky="w")
+    tk.Entry(spinner_frame, textvariable=tran_var, width=10).grid(row=2, column=1, padx=5, pady=2)
 
     display_frame = tk.Frame(root)
     display_frame.pack(fill=tk.BOTH, expand=True)
@@ -289,6 +293,7 @@ def main():
                 c3_var.get(),
                 v1_amp_var.get(),
                 v1_freq_var.get(),
+                tran_var.get(),
             )
         except Exception as exc:
             messagebox.showerror("Error", f"Simulation failed: {exc}")

--- a/pyltspicetest1.py
+++ b/pyltspicetest1.py
@@ -34,6 +34,7 @@ def run_simulation(
     c3_value: str | float = "2p",
     v1_amplitude: str | float = 1.0,
     v1_frequency: str | float = 5e5,
+    tran_params: str = "5u",
 ):
     """Run the LTspice simulation using a fixed op-amp test netlist.
 
@@ -60,6 +61,9 @@ def run_simulation(
         Peak value of the input pulse source ``V1`` in volts.
     v1_frequency:
         Frequency of the input pulse source ``V1`` in hertz.
+    tran_params:
+        Argument passed to the ``.tran`` control line. Any valid SPICE
+        transient analysis parameters may be used.
 
     Returns
     -------
@@ -100,7 +104,7 @@ def run_simulation(
         f"C3 Vout 0 {c3_value}",
         include_line,
         "* .ac dec 100 1K 20000K",
-        ".tran 5u",
+        f".tran {tran_params}",
         ".backanno",
         ".end",
     ]


### PR DESCRIPTION
## Summary
- add `tran` text entry in GUI
- pass `tran` parameters into simulation
- document `tran` entry in README

## Testing
- `python -m py_compile gui_runtime.py pyltspicetest1.py`

------
https://chatgpt.com/codex/tasks/task_e_68507297e2488327b43614c4f76509ee