### PR TITLE
Enable plot box zooming

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ is simply a large red circle acting as a placeholder for a future schematic.
 python gui_runtime.py
 ```
 
+The plot area supports box zooming.  Left-click and drag to draw a rectangle
+around the region of interest.  Release the mouse button to zoom the axes to
+that range.  Right-click inside the plot to reset to the original view.
+
 Upon completion, the script generates:
 
 - `opamp_test.net` – the generated netlist file


### PR DESCRIPTION
## Summary
- allow dragging a box over the matplotlib plot to zoom in
- right-click to reset zoom
- document the zoom controls in README

## Testing
- `python -m py_compile gui_runtime.py pyltspicetest1.py`
- `python -m tkinter` *(fails: no display name and no $DISPLAY environment variable)*
- `python pyltspicetest1.py` *(fails: ModuleNotFoundError: No module named 'PyLTSpice')*

------
https://chatgpt.com/codex/tasks/task_e_6850759956788327af4ec8807f3550c8