### PR TITLE
Add dotted rectangle for zoom selection

### DIFF
--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -177,7 +177,13 @@ def main():
         ax,
         onselect,
         button=[1],  # Left mouse button only
-        useblit=False,
+        useblit=True,
+        props=dict(
+            facecolor="none",
+            edgecolor="black",
+            linestyle=":",
+            linewidth=1,
+        ),
     )
 
     def reset_zoom(event):


### PR DESCRIPTION
## Summary
- show a dotted rectangle while zooming in `gui_runtime.py`

## Testing
- `python -m py_compile gui_runtime.py pyltspicetest1.py`

------
https://chatgpt.com/codex/tasks/task_e_685076ea7ef88327ab1a0b6da0fa5dc7