### PR TITLE
Limit FFT range

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ is simply a large red circle acting as a placeholder for a future schematic.
 
 An **FFT** button next to the `tran` entry computes the Fast Fourier Transform of
 the data currently visible in the plot. When clicked, the FFT magnitude plot
+displays frequencies from 1&nbsp;kHz to 200&nbsp;MHz on a logarithmic scale and
 replaces the time-domain results. Right-clicking inside the FFT plot restores
 the original simulation view.
 

--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -190,9 +190,24 @@ def main():
         freq = freq[1:]
         mag_db = mag_db[1:]
 
+        # Limit frequency range from 1 kHz to 200 MHz
+        min_freq = 1e3
+        max_freq = 200e6
+        freq_mask = (freq >= min_freq) & (freq <= max_freq)
+        freq = freq[freq_mask]
+        mag_db = mag_db[freq_mask]
+
+        if len(freq) == 0:
+            messagebox.showinfo(
+                "No data",
+                "No frequency components found between 1 kHz and 200 MHz.",
+            )
+            return
+
         ax.clear()
         ax.plot(freq, mag_db)
         ax.set_xscale("log")
+        ax.set_xlim(min_freq, max_freq)
         ax.set_title("FFT Magnitude")
         ax.set_xlabel("Frequency (Hz)")
         ax.set_ylabel("Magnitude (dB)")


### PR DESCRIPTION
## Summary
- restrict FFT display to 1 kHz–200 MHz
- document FFT frequency range in README

## Testing
- `python -m py_compile gui_runtime.py pyltspicetest1.py`

------
https://chatgpt.com/codex/tasks/task_e_6850867dc674832796157742de3bd459