### PR TITLE
Fix schemdraw popup window on startup

### DIFF
--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -63,7 +63,9 @@ def generate_schematic_image() -> Image:
     d.add(elm.Capacitor().down().label('C3\n50 pF'))
     d.add(elm.Ground())
 
-    d.draw()                   # show window / inline plot
+    # Draw the schematic without displaying a separate window so the
+    # image can be embedded directly in the GUI.
+    d.draw(show=False)
     # d.save('opamp_test.svg')  # optional export
 
     img_bytes = d.get_imagedata('png')


### PR DESCRIPTION
## Summary
- avoid showing the schemdraw figure in a separate window

## Testing
- `python -m py_compile gui_runtime.py pyltspicetest1.py`

------
https://chatgpt.com/codex/tasks/task_e_6851cfb34fe88327bea48a610da878fa