### PR TITLE
Add PDF report generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ displays frequencies from 1&nbsp;kHz to 200&nbsp;MHz on a logarithmic scale and
 replaces the time-domain results. Right-clicking inside the FFT plot restores
 the original simulation view.
 
+A **Save PDF** button exports the current plots and measurement results to
+`simulation_report.pdf`. Enable **Append to report** to add new pages instead of
+overwriting the existing file.
+
 ```bash
 python gui_runtime.py
 ```

--- a/report.py
+++ b/report.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+from matplotlib.backends.backend_pdf import PdfPages
+import matplotlib.pyplot as plt
+from PyPDF2 import PdfReader, PdfWriter
+
+
+def generate_pdf_report(
+    output_file: str,
+    time_data=None,
+    voltage_data=None,
+    freq_data=None,
+    mag_data=None,
+    measurements=None,
+    append: bool = False,
+) -> None:
+    """Generate a simple PDF report of the simulation results."""
+
+    figs = []
+    if time_data is not None and voltage_data is not None:
+        fig, ax = plt.subplots()
+        ax.plot(time_data, voltage_data)
+        ax.set_title("Output Voltage vs Time")
+        ax.set_xlabel("Time (s)")
+        ax.set_ylabel("Voltage (V)")
+        ax.grid(True)
+        figs.append(fig)
+
+    if freq_data is not None and mag_data is not None:
+        fig, ax = plt.subplots()
+        ax.plot(freq_data, mag_data)
+        ax.set_xscale("log")
+        ax.set_title("AC / FFT Magnitude")
+        ax.set_xlabel("Frequency (Hz)")
+        ax.set_ylabel("Magnitude (dB)")
+        ax.grid(True)
+        figs.append(fig)
+
+    if measurements:
+        fig, ax = plt.subplots(figsize=(6, 2))
+        ax.axis("off")
+        text = "\n".join(measurements)
+        ax.text(0.01, 0.95, text, va="top")
+        figs.append(fig)
+
+    temp_pdf = Path(output_file).with_suffix(".tmp.pdf")
+    with PdfPages(temp_pdf) as pdf:
+        for fig in figs:
+            pdf.savefig(fig)
+        plt.close('all')
+
+    if append and Path(output_file).exists():
+        writer = PdfWriter()
+        for page in PdfReader(output_file).pages:
+            writer.add_page(page)
+        for page in PdfReader(temp_pdf).pages:
+            writer.add_page(page)
+        with open(output_file, "wb") as f:
+            writer.write(f)
+        temp_pdf.unlink()
+    else:
+        temp_pdf.replace(output_file)


### PR DESCRIPTION
## Summary
- add new `generate_pdf_report` utility for saving plots to PDF
- import `generate_pdf_report` in the GUI and expose **Save PDF** button
- allow appending to a PDF report via checkbox
- document the new reporting feature in README

## Testing
- `python -m py_compile gui_runtime.py report.py pyltspicetest1.py`
- `pip install schemdraw`
- `pip install PyLTSpice`
- `DISPLAY= python gui_runtime.py` *(fails: couldn't connect to display)*

------
https://chatgpt.com/codex/tasks/task_e_685300a2ac208327aeb53ad1b31ecfcf