### PR TITLE
Handle missing PyPDF2 gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ pip install matplotlib
 ```bash
 pip install pillow
 ```
+- Install the Python package `PyPDF2` or `pypdf` to enable PDF report
+  generation:
+
+```bash
+pip install PyPDF2
+```
+
 
 ## Running the example
 

--- a/report.py
+++ b/report.py
@@ -1,7 +1,16 @@
 from pathlib import Path
 from matplotlib.backends.backend_pdf import PdfPages
 import matplotlib.pyplot as plt
-from PyPDF2 import PdfReader, PdfWriter
+
+try:  # Use PyPDF2 when available, fall back to pypdf
+    from PyPDF2 import PdfReader, PdfWriter
+except ModuleNotFoundError:  # pragma: no cover - environment may vary
+    try:
+        from pypdf import PdfReader, PdfWriter
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "PyPDF2 or pypdf is required for PDF report generation"
+        ) from exc
 
 
 def generate_pdf_report(


### PR DESCRIPTION
## Summary
- add fallback import for pypdf in `report.py`
- document PDF dependency in README

## Testing
- `python -m py_compile gui_runtime.py pyltspicetest1.py report.py`
- `pip install --disable-pip-version-check -q matplotlib PyPDF2` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685305702ce08327964f171fcf2ed0f2