### PR TITLE
Include schematic in PDF reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ Click **Load Model** to select the op-amp model file. The selected file is
 remembered across runs and its name is displayed to the right of the **RUN**
 button. Press **RUN** to run the simulation using the currently loaded model.
 The netlist is updated with the spinner values and the simulation result is
-plotted. After each run an image is shown to the right of the plot. For now this
-is simply a large red circle acting as a placeholder for a future schematic.
+plotted. After each run a schematic diagram reflecting the chosen component
+values is shown to the right of the plot. This same diagram is included on the
+first page of the PDF report together with the measured slew rate and settling
+time.
 
 An **FFT** button next to the `tran` entry computes the Fast Fourier Transform of
 the data currently visible in the plot. When clicked, the FFT magnitude plot

--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -161,6 +161,8 @@ def main():
     tran_var = tk.StringVar(value="5u")
     ac_var = tk.StringVar(value="dec 100 1K 20000K")
 
+    last_schematic_img = None
+
     tk.Label(spinner_frame, text="R9 (FB)").grid(row=0, column=0, padx=5, pady=2, sticky="w")
     tk.Spinbox(spinner_frame, from_=1, to=1e6, increment=100, textvariable=r9_var, width=8).grid(row=0, column=1, padx=5, pady=2)
     tk.Label(spinner_frame, text="C1 (FB)").grid(row=0, column=2, padx=5, pady=2, sticky="w")
@@ -483,6 +485,8 @@ def main():
     schematic_label.configure(image=tk_img)
     schematic_label.image = tk_img
 
+    last_schematic_img = schematic_img
+
     # Resize the window so the image is shown at its natural size
     root.update_idletasks()
     canvas_width = canvas_widget.winfo_width() or int(
@@ -518,7 +522,7 @@ def main():
     def run_simulation():
         """Run the simulation using the currently loaded model."""
 
-        nonlocal orig_xlim, orig_ylim, time_data, voltage_data, freq_data, mag_data, showing_fft
+        nonlocal orig_xlim, orig_ylim, time_data, voltage_data, freq_data, mag_data, showing_fft, last_schematic_img
 
         if not current_model:
             messagebox.showinfo(
@@ -541,6 +545,10 @@ def main():
         tk_img_local = ImageTk.PhotoImage(schematic_img)
         schematic_label.configure(image=tk_img_local)
         schematic_label.image = tk_img_local
+        last_schematic_img = schematic_img
+        last_schematic_img = schematic_img
+        last_schematic_img = schematic_img
+        last_schematic_img = schematic_img
 
         try:
             time_wave, v_cap_wave, sr_90_10, sr_80_20, settling_time = pyltspicetest1.run_simulation(
@@ -596,6 +604,7 @@ def main():
                 freq_data=freq_data,
                 mag_data=mag_data,
                 measurements=meas,
+                schematic_image=last_schematic_img,
                 append=append_var.get(),
             )
             messagebox.showinfo(
@@ -623,7 +632,7 @@ def main():
     def run_ac():
         """Run an AC simulation and plot the frequency response."""
 
-        nonlocal orig_xlim, orig_ylim, time_data, voltage_data, freq_data, mag_data, showing_fft
+        nonlocal orig_xlim, orig_ylim, time_data, voltage_data, freq_data, mag_data, showing_fft, last_schematic_img
 
         if not current_model:
             messagebox.showinfo(
@@ -645,6 +654,7 @@ def main():
         tk_img_local = ImageTk.PhotoImage(schematic_img)
         schematic_label.configure(image=tk_img_local)
         schematic_label.image = tk_img_local
+        last_schematic_img = schematic_img
 
         try:
             freq_wave, mag_db = pyltspicetest1.run_ac_simulation(

--- a/report.py
+++ b/report.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from matplotlib.backends.backend_pdf import PdfPages
 import matplotlib.pyplot as plt
+from PIL import Image
 
 try:  # Use PyPDF2 when available, fall back to pypdf
     from PyPDF2 import PdfReader, PdfWriter
@@ -20,11 +21,48 @@ def generate_pdf_report(
     freq_data=None,
     mag_data=None,
     measurements=None,
+    schematic_image: Image | None = None,
     append: bool = False,
 ) -> None:
-    """Generate a simple PDF report of the simulation results."""
+    """Generate a simple PDF report of the simulation results.
+
+    Parameters
+    ----------
+    output_file:
+        Destination PDF file.
+    time_data, voltage_data:
+        Data for the time-domain plot.
+    freq_data, mag_data:
+        Data for the AC or FFT plot.
+    measurements:
+        Iterable of strings to display on a separate page or alongside the
+        schematic.
+    schematic_image:
+        ``PIL.Image`` containing the circuit diagram to embed on the first
+        page. When provided, measurement text is shown on top of this image.
+    append:
+        If ``True`` and *output_file* already exists, append new pages instead of
+        overwriting the file.
+    """
 
     figs = []
+
+    if schematic_image is not None:
+        fig, ax = plt.subplots()
+        ax.imshow(schematic_image)
+        ax.axis("off")
+        if measurements:
+            text = "\n".join(measurements)
+            ax.text(
+                0.01,
+                0.95,
+                text,
+                transform=ax.transAxes,
+                va="top",
+                bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
+            )
+        figs.append(fig)
+        measurements = None
     if time_data is not None and voltage_data is not None:
         fig, ax = plt.subplots()
         ax.plot(time_data, voltage_data)


### PR DESCRIPTION
## Summary
- embed a schematic page in PDF reports
- display the schematic with updated values when running AC or transient
- document new behaviour in the README

## Testing
- `python -m py_compile $(ls *.py)`

------
https://chatgpt.com/codex/tasks/task_e_68530851db748327924757a6492f364b