### PR TITLE
Fix PIL Image union annotation

### DIFF
--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 from matplotlib.widgets import RectangleSelector
 from matplotlib.ticker import FuncFormatter
 from PIL import Image, ImageTk
+from PIL.Image import Image as PilImage
 import io
 import schemdraw
 import schemdraw.elements as elm
@@ -54,7 +55,7 @@ def generate_schematic_image(
     c3_value: float,
     v1_amplitude: float,
     v1_frequency: float,
-) -> Image:
+) -> PilImage:
     """Return a PIL Image of the op-amp test circuit."""
 
     d = schemdraw.Drawing(unit=2.2, fontsize=12)

--- a/report.py
+++ b/report.py
@@ -1,7 +1,10 @@
 from pathlib import Path
+from typing import Optional
+
 from matplotlib.backends.backend_pdf import PdfPages
 import matplotlib.pyplot as plt
 from PIL import Image
+from PIL.Image import Image as PilImage
 
 try:  # Use PyPDF2 when available, fall back to pypdf
     from PyPDF2 import PdfReader, PdfWriter
@@ -21,7 +24,7 @@ def generate_pdf_report(
     freq_data=None,
     mag_data=None,
     measurements=None,
-    schematic_image: Image | None = None,
+    schematic_image: Optional[PilImage] = None,
     append: bool = False,
 ) -> None:
     """Generate a simple PDF report of the simulation results.


### PR DESCRIPTION
## Summary
- import the `Image` class for type hints
- update `report.generate_pdf_report` parameter type
- update `gui_runtime.generate_schematic_image` return type

## Testing
- `python -m py_compile gui_runtime.py report.py pyltspicetest1.py`

------
https://chatgpt.com/codex/tasks/task_e_68530a27c4248327b76bee57fdcf6c3b