### PR TITLE
Fix placement of measurement text in PDF report

### DIFF
--- a/report.py
+++ b/report.py
@@ -56,11 +56,11 @@ def generate_pdf_report(
         ax.axis("off")
         if measurements:
             text = "\n".join(measurements)
-            ax.text(
-                0.01,
-                0.95,
+            fig.text(
+                0.02,
+                0.98,
                 text,
-                transform=ax.transAxes,
+                ha="left",
                 va="top",
                 bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
             )


### PR DESCRIPTION
## Summary
- place slew rate and settling time text at the upper left corner when generating PDF reports

## Testing
- `python -m py_compile report.py gui_runtime.py pyltspicetest1.py`
- `python - <<'PY'
import matplotlib
matplotlib.use('Agg')
from report import generate_pdf_report
from PIL import Image, ImageDraw
img=Image.new('RGB',(200,100),'white');ImageDraw.Draw(img).rectangle([50,40,150,60],outline='black')
meas=['Slew:1','Settling:2']
generate_pdf_report('test_report.pdf',measurements=meas,schematic_image=img)
print('done')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68530d31620883279cb0b2b92c36b031