### PR TITLE
Add timestamped PDF report names

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ displays frequencies from 1&nbsp;kHz to 200&nbsp;MHz on a logarithmic scale and
 replaces the time-domain results. Right-clicking inside the FFT plot restores
 the original simulation view.
 
-A **Save PDF** button exports the current plots and measurement results to
-`simulation_report.pdf`. Enable **Append to report** to add new pages instead of
-overwriting the existing file.
+A **Save PDF** button exports the current plots and measurement results to a
+timestamped file such as `simulation_report_20240101_120000.pdf`. Enable
+**Append to report** to add new pages to the current file instead of overwriting
+it.
 
 ```bash
 python gui_runtime.py

--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -1,6 +1,7 @@
 import tkinter as tk
 from tkinter import messagebox, filedialog
 from pathlib import Path
+from datetime import datetime
 
 from report import generate_pdf_report
 
@@ -583,9 +584,12 @@ def main():
     run_frame.grid(row=0, column=1, padx=5, pady=0, sticky="w")
 
     append_var = tk.BooleanVar(value=False)
+    current_report_file: str | None = None
 
     def save_pdf() -> None:
         """Save a PDF report of the current results."""
+
+        nonlocal current_report_file
 
         meas = [
             s
@@ -597,9 +601,13 @@ def main():
             if s
         ]
 
+        if current_report_file is None or not append_var.get():
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            current_report_file = f"simulation_report_{timestamp}.pdf"
+
         try:
             generate_pdf_report(
-                "simulation_report.pdf",
+                current_report_file,
                 time_data=time_data,
                 voltage_data=voltage_data,
                 freq_data=freq_data,
@@ -609,7 +617,7 @@ def main():
                 append=append_var.get(),
             )
             messagebox.showinfo(
-                "PDF Saved", "Report written to simulation_report.pdf"
+                "PDF Saved", f"Report written to {current_report_file}"
             )
         except Exception as exc:
             messagebox.showerror("Error", f"Failed to generate PDF: {exc}")


### PR DESCRIPTION
## Summary
- use `datetime` to generate timestamped report names in the GUI
- keep using the same file when appending
- document timestamped reports in README

## Testing
- `python -m py_compile gui_runtime.py report.py pyltspicetest1.py`

------
https://chatgpt.com/codex/tasks/task_e_685314f6e8f48327bb25dae99092b1d3