### PR TITLE
Add sine/pulse source toggle

### DIFF
--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -160,6 +160,7 @@ def main():
     c3_var = tk.DoubleVar(value=2e-12)
     v1_amp_var = tk.DoubleVar(value=1.0)
     v1_freq_var = tk.DoubleVar(value=5e5)
+    use_sine_var = tk.BooleanVar(value=False)
     tran_var = tk.StringVar(value="5u")
     ac_var = tk.StringVar(value="dec 100 1K 20000K")
 
@@ -273,6 +274,12 @@ def main():
         textvariable=v1_freq_var,
         width=8,
     ).grid(row=1, column=7, padx=5, pady=2)
+
+    tk.Checkbutton(
+        spinner_frame,
+        text="Sine Source",
+        variable=use_sine_var,
+    ).grid(row=2, column=6, columnspan=2, padx=5, pady=2, sticky="w")
 
     tk.Label(spinner_frame, text="tran").grid(row=2, column=0, padx=5, pady=2, sticky="w")
     tk.Entry(spinner_frame, textvariable=tran_var, width=10).grid(row=2, column=1, padx=5, pady=2)
@@ -563,6 +570,7 @@ def main():
                 c3_var.get(),
                 v1_amp_var.get(),
                 v1_freq_var.get(),
+                use_sine_var.get(),
                 tran_var.get(),
             )
         except Exception as exc:

--- a/pyltspicetest1.py
+++ b/pyltspicetest1.py
@@ -34,6 +34,7 @@ def run_simulation(
     c3_value: str | float = "2p",
     v1_amplitude: str | float = 1.0,
     v1_frequency: str | float = 5e5,
+    use_sine: bool = False,
     tran_params: str = "5u",
 ):
     """Run the LTspice simulation using a fixed op-amp test netlist.
@@ -58,9 +59,11 @@ def run_simulation(
     c3_value:
         Value of the load capacitor ``C3``.
     v1_amplitude:
-        Peak value of the input pulse source ``V1`` in volts.
+        Peak value of the input source ``V1`` in volts.
     v1_frequency:
-        Frequency of the input pulse source ``V1`` in hertz.
+        Frequency of the input source ``V1`` in hertz.
+    use_sine:
+        When ``True`` use a sinusoidal source instead of a pulse.
     tran_params:
         Argument passed to the ``.tran`` control line. Any valid SPICE
         transient analysis parameters may be used.
@@ -89,6 +92,10 @@ def run_simulation(
 
     period = 1 / float(v1_frequency)
     ton = period / 2
+    if use_sine:
+        v1_line = f"V1 N002 0 SIN(0 {v1_amplitude} {v1_frequency})"
+    else:
+        v1_line = f"V1 N002 0 PULSE(0 {v1_amplitude} 0 1n 1n {ton} {period})"
 
     netlist_lines = [
         "* E:\\LTSpice_Models\\activeBP2 - Copy\\opamptest1.asc",
@@ -97,7 +104,7 @@ def run_simulation(
         f"R9 Vout N001 {r9_value}",
         f"XU2 N002 N001 VCC -VCC Vout {subckt_name}",
         f"R3 Vout 0 {r3_value}",
-        f"V1 N002 0 PULSE(0 {v1_amplitude} 0 1n 1n {ton} {period})",
+        v1_line,
         f"R1 N001 0 {r1_value}",
         f"C1 Vout N001 {c1_value}",
         f"C2 N002 0 {c2_value}",


### PR DESCRIPTION
## Summary
- allow run_simulation to use a sine or pulse source
- add a checkbox in the GUI to select the source type

## Testing
- `python -m py_compile gui_runtime.py pyltspicetest1.py report.py`
- `python gui_runtime.py` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_6853193767cc832784c4c65c2a4db04b