### PR TITLE
Fix FFT title in PDF

### DIFF
--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -623,6 +623,7 @@ def main():
                 measurements=meas,
                 schematic_image=last_schematic_img,
                 append=append_var.get(),
+                freq_plot_title="FFT Magnitude" if showing_fft else "AC Magnitude",
             )
             messagebox.showinfo(
                 "PDF Saved", f"Report written to {current_report_file}"

--- a/report.py
+++ b/report.py
@@ -26,6 +26,7 @@ def generate_pdf_report(
     measurements=None,
     schematic_image: Optional[PilImage] = None,
     append: bool = False,
+    freq_plot_title: str = "FFT Magnitude",
 ) -> None:
     """Generate a simple PDF report of the simulation results.
 
@@ -36,7 +37,8 @@ def generate_pdf_report(
     time_data, voltage_data:
         Data for the time-domain plot.
     freq_data, mag_data:
-        Data for the AC or FFT plot.
+        Data for the frequency-domain plot.  The *freq_plot_title*
+        parameter controls the title shown on this page.
     measurements:
         Iterable of strings to display on a separate page or alongside the
         schematic.
@@ -46,6 +48,9 @@ def generate_pdf_report(
     append:
         If ``True`` and *output_file* already exists, append new pages instead of
         overwriting the file.
+    freq_plot_title:
+        Title to use for the frequency-domain plot when ``freq_data`` and
+        ``mag_data`` are provided.
     """
 
     figs = []
@@ -79,7 +84,7 @@ def generate_pdf_report(
         fig, ax = plt.subplots()
         ax.plot(freq_data, mag_data)
         ax.set_xscale("log")
-        ax.set_title("AC / FFT Magnitude")
+        ax.set_title(freq_plot_title)
         ax.set_xlabel("Frequency (Hz)")
         ax.set_ylabel("Magnitude (dB)")
         ax.grid(True)


### PR DESCRIPTION
## Summary
- label the FFT plot correctly in generated PDF reports
- allow `generate_pdf_report()` to accept custom frequency plot titles

## Testing
- `python -m py_compile report.py gui_runtime.py pyltspicetest1.py`

------
https://chatgpt.com/codex/tasks/task_e_685330b4322c83278cdf40f88e2c88f4