### PR TITLE
Allow TXT models in open dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ increment in 1&nbsp;pF steps. The `C2` and `C3` controls appear to the right of
 the `C1` and `R3` pair, stacked vertically. The new `V1` controls are positioned
 to their right, leaving the **RUN**, **RUN AC** and **Load Model** buttons on the far right.
 
-Click **Load Model** to select the op-amp model file. The selected file is
-remembered across runs and its name is displayed to the right of the **RUN**
-button. Press **RUN** to run the simulation using the currently loaded model.
+Click **Load Model** to select the op-amp model file. The dialog filters for
+both `.lib` and `.txt` files. The selected file is remembered across runs and
+its name is displayed to the right of the **RUN** button. Press **RUN** to run
+the simulation using the currently loaded model.
 The netlist is updated with the spinner values and the simulation result is
 plotted. After each run a schematic diagram reflecting the chosen component
 values is shown to the right of the plot. This same diagram is included on the

--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -511,7 +511,7 @@ def main():
         nonlocal current_model
         lib_path = filedialog.askopenfilename(
             title="Select op-amp model",
-            filetypes=[("SPICE model", "*.lib"), ("All files", "*.*")],
+            filetypes=[("SPICE model", "*.lib *.txt"), ("All files", "*.*")],
         )
         if not lib_path:
             return

--- a/pyltspicetest1.py
+++ b/pyltspicetest1.py
@@ -42,10 +42,11 @@ def run_simulation(
     Parameters
     ----------
     lib_path:
-        Optional path to an op-amp ``.lib`` model file. When provided, the
-        ``.include`` statement in the generated netlist will reference this
-        absolute path. Otherwise the short file name ``lm7171.lib`` is used and
-        the model is assumed to define the ``LM7171`` subcircuit.
+        Optional path to an op-amp ``.lib`` or ``.txt`` model file. When
+        provided, the ``.include`` statement in the generated netlist will
+        reference this absolute path. Otherwise the short file name
+        ``lm7171.lib`` is used and the model is assumed to define the
+        ``LM7171`` subcircuit.
     r9_value:
         Value of the gain resistor ``R9``.
     r1_value:


### PR DESCRIPTION
## Summary
- mention .txt filter in README
- document .txt support in `run_simulation`
- allow .txt models in GUI file-open dialog

## Testing
- `python -m py_compile gui_runtime.py pyltspicetest1.py report.py`

------
https://chatgpt.com/codex/tasks/task_e_68544994de7883279426d6e3240e9927