### PR TITLE
Fix CTRL pan vs zoom conflict

### DIFF
--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -431,6 +431,25 @@ def main():
         ),
     )
 
+    ctrl_pressed = False
+
+    def on_key_press(event) -> None:
+        """Disable zoom rectangle when CTRL is pressed."""
+        nonlocal ctrl_pressed
+        if event.key is not None and "control" in str(event.key).lower():
+            ctrl_pressed = True
+            rect_selector.set_active(False)
+
+    def on_key_release(event) -> None:
+        """Re-enable zoom rectangle after CTRL release."""
+        nonlocal ctrl_pressed
+        if event.key is not None and "control" in str(event.key).lower():
+            ctrl_pressed = False
+            rect_selector.set_active(True)
+
+    canvas.mpl_connect("key_press_event", on_key_press)
+    canvas.mpl_connect("key_release_event", on_key_release)
+
     def plot_time_domain() -> None:
         """Plot the stored time-domain data."""
 
@@ -468,11 +487,7 @@ def main():
     def pan_start_event(event):
         """Begin panning when CTRL + left mouse button is pressed."""
         nonlocal pan_start
-        if (
-            event.button != 1
-            or event.key is None
-            or "control" not in str(event.key).lower()
-        ):
+        if event.button != 1 or not ctrl_pressed:
             return
 
         if orig_xlim[0] is None:


### PR DESCRIPTION
## Summary
- disable RectangleSelector when CTRL is pressed
- use a pressed key tracker so CTRL pans without triggering zoom

## Testing
- `python -m py_compile gui_runtime.py pyltspicetest1.py report.py`

------
https://chatgpt.com/codex/tasks/task_e_6854573ab2f8832795c7964aafda1fce