### PR TITLE
Enable zoom-aware PDF export

### DIFF
--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -709,6 +709,14 @@ def main():
             current_report_file = f"simulation_report_{timestamp}.pdf"
 
         try:
+            cur_xlim = ax.get_xlim()
+            cur_ylim = ax.get_ylim()
+            is_log = ax.get_xscale() == "log"
+            time_xlim = cur_xlim if not is_log and time_data is not None else None
+            time_ylim = cur_ylim if not is_log and time_data is not None else None
+            freq_xlim = cur_xlim if is_log and freq_data is not None else None
+            freq_ylim = cur_ylim if is_log and freq_data is not None else None
+
             generate_pdf_report(
                 current_report_file,
                 time_data=time_data,
@@ -719,6 +727,10 @@ def main():
                 schematic_image=last_schematic_img,
                 append=append_var.get(),
                 freq_plot_title="FFT Magnitude" if showing_fft else "AC Magnitude",
+                time_xlim=time_xlim,
+                time_ylim=time_ylim,
+                freq_xlim=freq_xlim,
+                freq_ylim=freq_ylim,
             )
             messagebox.showinfo(
                 "PDF Saved", f"Report written to {current_report_file}"

--- a/report.py
+++ b/report.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 from matplotlib.backends.backend_pdf import PdfPages
 import matplotlib.pyplot as plt
@@ -27,6 +27,10 @@ def generate_pdf_report(
     schematic_image: Optional[PilImage] = None,
     append: bool = False,
     freq_plot_title: str = "FFT Magnitude",
+    time_xlim: Optional[Tuple[float, float]] = None,
+    time_ylim: Optional[Tuple[float, float]] = None,
+    freq_xlim: Optional[Tuple[float, float]] = None,
+    freq_ylim: Optional[Tuple[float, float]] = None,
 ) -> None:
     """Generate a simple PDF report of the simulation results.
 
@@ -51,6 +55,10 @@ def generate_pdf_report(
     freq_plot_title:
         Title to use for the frequency-domain plot when ``freq_data`` and
         ``mag_data`` are provided.
+    time_xlim, time_ylim:
+        Optional axis limits for the time-domain plot.
+    freq_xlim, freq_ylim:
+        Optional axis limits for the frequency-domain plot.
     """
 
     figs = []
@@ -78,6 +86,10 @@ def generate_pdf_report(
         ax.set_xlabel("Time (s)")
         ax.set_ylabel("Voltage (V)")
         ax.grid(True)
+        if time_xlim is not None:
+            ax.set_xlim(time_xlim)
+        if time_ylim is not None:
+            ax.set_ylim(time_ylim)
         figs.append(fig)
 
     if freq_data is not None and mag_data is not None:
@@ -88,6 +100,10 @@ def generate_pdf_report(
         ax.set_xlabel("Frequency (Hz)")
         ax.set_ylabel("Magnitude (dB)")
         ax.grid(True)
+        if freq_xlim is not None:
+            ax.set_xlim(freq_xlim)
+        if freq_ylim is not None:
+            ax.set_ylim(freq_ylim)
         figs.append(fig)
 
     if measurements:


### PR DESCRIPTION
## Summary
- preserve zoom range when saving PDF reports
- wire up optional axis limits through generate_pdf_report

## Testing
- `python -m py_compile gui_runtime.py report.py pyltspicetest1.py`

------
https://chatgpt.com/codex/tasks/task_e_685464b03ea48327a1e21f4a0ebfd9a2