### PR TITLE
Fix zoom rectangle origin after panning

### DIFF
--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -431,6 +431,14 @@ def main():
             linewidth=1,
         ),
     )
+    # Disable the built-in "center" mode which is toggled with CTRL. This
+    # prevents the selector from interpreting the first click as the rectangle
+    # center after panning with the CTRL key held down.
+    try:
+        rect_selector.remove_state("center")
+    except ValueError:
+        # Older Matplotlib versions may not support removing states.
+        pass
 
     ctrl_pressed = False
     grid_disabled = False


### PR DESCRIPTION
## Summary
- prevent RectangleSelector from entering center-origin mode

## Testing
- `python -m py_compile gui_runtime.py pyltspicetest1.py report.py`

------
https://chatgpt.com/codex/tasks/task_e_6854674218388327ae1ea92429590c31