### PR TITLE
Fix RectangleSelector remove_state error

### DIFF
--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -436,8 +436,9 @@ def main():
     # center after panning with the CTRL key held down.
     try:
         rect_selector.remove_state("center")
-    except ValueError:
-        # Older Matplotlib versions may not support removing states.
+    except (ValueError, KeyError):
+        # Older Matplotlib versions may not support removing states or
+        # the state might not exist in newer versions.
         pass
 
     ctrl_pressed = False


### PR DESCRIPTION
## Summary
- catch KeyError when removing the `center` state in `gui_runtime.py`

## Testing
- `python -m py_compile gui_runtime.py pyltspicetest1.py report.py`
- `python gui_runtime.py` *(fails: no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68546963e598832788fb30e512687bcb