### PR TITLE
Fix zoom rectangle after panning

### DIFF
--- a/gui_runtime.py
+++ b/gui_runtime.py
@@ -430,16 +430,11 @@ def main():
             linestyle=":",
             linewidth=1,
         ),
+        # Disable the built-in "center" mode so CTRL-drag doesn't switch
+        # the selector to interpreting the first click as the rectangle
+        # center after panning.
+        state_modifier_keys={"center": "not-applicable"},
     )
-    # Disable the built-in "center" mode which is toggled with CTRL. This
-    # prevents the selector from interpreting the first click as the rectangle
-    # center after panning with the CTRL key held down.
-    try:
-        rect_selector.remove_state("center")
-    except (ValueError, KeyError):
-        # Older Matplotlib versions may not support removing states or
-        # the state might not exist in newer versions.
-        pass
 
     ctrl_pressed = False
     grid_disabled = False


### PR DESCRIPTION
## Summary
- disable RectangleSelector "center" mode using `state_modifier_keys`
- keep zoom rectangle disabled until Ctrl is released

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685474d1f0b883279b4f940d166bda81