### PR TITLE
Add VPP measurement

### DIFF
--- a/measurements.py
+++ b/measurements.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+import numpy as np
+
+
+def compute_vpp(
+    x_data: np.ndarray, xlim: tuple[float, float], y_data: np.ndarray
+) -> tuple[float, float, float, float, float]:
+    """Return Vpp and max/min points within *xlim*."""
+
+    start, end = xlim
+    if start > end:
+        start, end = end, start
+    mask = (x_data >= start) & (x_data <= end)
+    if not np.any(mask):
+        raise ValueError("No points in range")
+
+    x_sel = x_data[mask]
+    y_sel = y_data[mask]
+
+    idx_max = int(np.argmax(y_sel))
+    idx_min = int(np.argmin(y_sel))
+
+    v_max = float(y_sel[idx_max])
+    v_min = float(y_sel[idx_min])
+    t_max = float(x_sel[idx_max])
+    t_min = float(x_sel[idx_min])
+
+    return v_max - v_min, t_max, v_max, t_min, v_min

--- a/tests/test_vpp.py
+++ b/tests/test_vpp.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from measurements import compute_vpp
+
+
+def test_compute_vpp_full_range():
+    t = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    v = np.array([0.0, 1.0, 0.0, -1.0, 0.5])
+    vpp, t_max, v_max, t_min, v_min = compute_vpp(t, (0.0, 4.0), v)
+    assert vpp == pytest.approx(2.0)
+    assert t_max == pytest.approx(1.0)
+    assert v_max == pytest.approx(1.0)
+    assert t_min == pytest.approx(3.0)
+    assert v_min == pytest.approx(-1.0)
+
+
+def test_compute_vpp_zoom_range():
+    t = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    v = np.array([0.0, 1.0, 0.0, -1.0, 0.5])
+    vpp, t_max, v_max, t_min, v_min = compute_vpp(t, (0.5, 2.5), v)
+    assert vpp == pytest.approx(1.0)
+    assert t_max == pytest.approx(1.0)
+    assert v_max == pytest.approx(1.0)
+    assert t_min == pytest.approx(2.0)
+    assert v_min == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- add generic `compute_vpp` helper to `measurements.py`
- integrate VPP measurement UI with red marker points
- clear markers when changing views
- unit tests for VPP computation

## Testing
- `pip install matplotlib numpy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b1feee0c8327af6c85baecbfdd06